### PR TITLE
Refactor Match_sports to use FormatData

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,11 @@
 
+[Refactor Match_sports to use FormatData] - 2025-11-29
+
+- Added: Cached loader for the sports match formatter built on FormatData.
+- Changed: Refactored Match_sports resolver to delegate matching and formatting to FormatData with placeholder-aware mapping.
+- Fixed: Ensured sports match labels reuse centralized normalization logic for consistent Arabic output.
+- Removed: Deprecated manual matching helpers from the Match_sports module.
+
 ## [#125](https://github.com/MrIbrahem/ArWikiCats/pull/125) - 2025-11-29
 
 * **New Features**


### PR DESCRIPTION
## Summary
- refactor `Match_sports` module to delegate label resolution to the shared `FormatData` helper
- add cached formatter construction with explicit placeholders for sports templates
- document the refactor in the changelog

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692aa036ee748322b8272ac49415cf24)